### PR TITLE
Update capabilities to fix fetch detection in chrome

### DIFF
--- a/lib/capability.js
+++ b/lib/capability.js
@@ -1,4 +1,4 @@
-exports.fetch = isFunction(window.fetch) && isFunction(window.ReadableByteStream)
+exports.fetch = isFunction(window.fetch) && (isFunction(window.ReadableStream) || isFunction(window.ReadableByteStream))
 
 exports.blobConstructor = false
 try {


### PR DESCRIPTION
Spec now uses ReadableStream rather than ReadableByteStream. In chrome ReadableByteStream is no longer available on window so the existing check in capabilities for fetch was failing. The fix is to check both.